### PR TITLE
Grammatical error fix

### DIFF
--- a/resources/assets/js/views/Faq.js
+++ b/resources/assets/js/views/Faq.js
@@ -57,3 +57,4 @@ class Faq extends React.Component {
 }
 
 export default Faq;
+

--- a/resources/assets/js/views/Faq.js
+++ b/resources/assets/js/views/Faq.js
@@ -37,7 +37,7 @@ class Faq extends React.Component {
 				<div className="question">
 					<h2>what file types are accepted?</h2>
 					<div className="answer">
-						as of now all file types are accepted a part from executable files.
+						as of now all file types are accepted apart from executable files.
 					</div>
 				</div>
 				<div className="question">


### PR DESCRIPTION
This is affecting my OCD.

'**Apart**' is normally used as an adverb. It can be a part of a preposition when joined with the word from. 
'**A part**' is a noun.